### PR TITLE
feat(ci): add Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps): "
+    reviewers:
+      - "mzdm"
+      - "MartinMacek"
+      - "ichlubna"


### PR DESCRIPTION
experiment s [Dependabot](https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/) pro Dart/Flutter balíčky, abychom je měli up-to-date

dependencies se checkují každý týden