### PR TITLE
feat: GitHub Actions Android release workflow for testing purposes

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
-      - name: Build apk
-        run: flutter build apk --release
-
       - name: Run prebuild script
         run: sh ./bin/ci_workflow_scripts/prebuild.sh ${{github.run_number}}
+
+      - name: Build apk
+        run: flutter build apk --release
 
       - name: GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,8 +1,8 @@
-name: Continuous Integration / build
+name: Continuous Integration / GitHub release
 on:
   push:
     branches: [ main ]
-  pull_request:
+  workflow_dispatch: # can be triggered manually
 
 env:
   flutter_version: '3.0.5'
@@ -28,23 +28,14 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build apk
-        run: flutter build apk --debug
+        run: flutter build apk --release
 
-  ios:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Flutter SDK cache
-        uses: subosito/flutter-action@v2
+      - name: GitHub release
+        uses: ncipollo/release-action@v1
+        if: github.event_name != 'pull_request'
         with:
-          flutter-version: ${{ env.flutter_version }}
-          cache: true
-          cache-key: ${{ runner.OS }}-flutter-${{ env.flutter_version }}
-          cache-path: ${{ runner.tool_cache }}/flutter
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Build ios
-        run: flutter build ios --debug --no-codesign --simulator
+          name: Android build (dev-0.0.${{github.run_number}})
+          commit: ${{ github.sha }}
+          tag: dev-0.0.${{github.run_number}}
+          artifacts: "build/app/outputs/flutter-apk/app-release.apk"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Run prebuild script
-        run: sh ./bin/ci_workflow_scripts/prebuild.sh
+        run: sh ./bin/ci_workflow_scripts/prebuild.sh ${{github.run_number}}
 
       - name: GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build apk
         run: flutter build apk --release
 
+      - name: Run prebuild script
+        run: sh ./bin/ci_workflow_scripts/prebuild.sh
+
       - name: GitHub release
         uses: ncipollo/release-action@v1
         if: github.event_name != 'pull_request'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.dontpanic">
    <application
-        android:label="nepanikar"
+        android:label="Nepanikař"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/bin/ci_workflow_scripts/prebuild.sh
+++ b/bin/ci_workflow_scripts/prebuild.sh
@@ -1,0 +1,6 @@
+sed -i -e "s#package=\"org.dontpanic\"#package=\"org.dontpanic.dev\"#" android/app/src/main/AndroidManifest.xml
+sed -i -e "s#android:label=\"Nepanikař\"#android:label=\"Nepanikař [dev]\"#" android/app/src/main/AndroidManifest.xml
+sed -i -e "s#applicationId \"org.dontpanic\"#applicationId \"org.dontpanic.dev\"#" android/app/build.gradle
+sed -i -e "s#package org.dontpanic#package org.dontpanic.dev#" android/app/src/main/kotlin/org/dontpanic/MainActivity.kt
+sed -i -e "s#title: 'Nepanikař'#title: 'Nepanikař [dev]'" lib/main.dart
+sed -i -e "s#version: 0.0.1#version: 0.0.$1#" pubspec.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: nepanikar
 description: First aid for psychological issues.
 publish_to: 'none'
-version: 1.0.0+1
+version: 0.0.1
 
 environment:
   sdk: ">=2.17.6 <3.0.0"


### PR DESCRIPTION
Dočasné workflow než bude lepší řešení, které po každém commitu do `mainu` zbuildí apkčko na Android, přes které se to dá lehce nainstalovat a otestovat.

Apkčka by měly být vpravo v menu v [Releases](https://github.com/cesko-digital/nepanikar/releases):
![image](https://user-images.githubusercontent.com/67197047/193122584-e81cd431-b1c4-4c5a-9e16-d68303363fdc.png)

PS: Přejmenovávám tam na dev verzi protože nemůže být na devicu zaroven nainstalovaná i orig. verze appka (stejné appId) - přijde mi takto lepší že můžou být obě appky nainstalované zároven

PS2: Netuším jak moc dobře toto fungovat. ASi nezbývá než vyzkoušet v praxi


