### PR TITLE
refactor(db): better db modularization

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.dontpanic">
    <application
         android:label="Nepanikař"
         android:name="${applicationName}"

--- a/bin/ci_workflow_scripts/prebuild_v2.sh
+++ b/bin/ci_workflow_scripts/prebuild_v2.sh
@@ -1,6 +1,7 @@
 # This generates .apk with different applicationId so that it can be
 # installed without overriding the original app.
 
+sed -i -e "s#package=\"org.dontpanic\"#package=\"org.dontpanic.dev\"#" android/app/src/main/AndroidManifest.xml
 sed -i -e "s#android:label=\"Nepanikař\"#android:label=\"Nepanikař v2 [dev]\"#" android/app/src/main/AndroidManifest.xml
 sed -i -e "s#applicationId \"org.dontpanic\"#applicationId \"org.dontpanic.dev\"#" android/app/build.gradle
 sed -i -e "s#namespace \"org.dontpanic\"#namespace \"org.dontpanic.dev\"#" android/app/build.gradle

--- a/lib/services/db/common/nepanikar_checklist_form_dao.dart
+++ b/lib/services/db/common/nepanikar_checklist_form_dao.dart
@@ -54,6 +54,10 @@ abstract class NepanikarCheckListFormDao {
         return Map.fromEntries(entries);
       });
 
+  Future<void> doOldVersionMigration() async {
+    // TODO: implement doOldVersionMigration
+  }
+
   Future<void> clear() async {
     await _store.drop(_db);
   }

--- a/lib/services/db/common/nepanikar_list_form_dao.dart
+++ b/lib/services/db/common/nepanikar_list_form_dao.dart
@@ -33,6 +33,10 @@ abstract class NepanikarListFormDao {
   Stream<List<RecordSnapshot<String, ListFormItem>>> get allFormItemsRecordsStream =>
       _store.query().onSnapshots(_db);
 
+  Future<void> doOldVersionMigration() async {
+    // TODO: implement doOldVersionMigration
+  }
+
   Future<void> clear() async {
     await _store.drop(_db);
   }

--- a/lib/services/db/common/nepanikar_module_db.dart
+++ b/lib/services/db/common/nepanikar_module_db.dart
@@ -1,0 +1,5 @@
+abstract class NepanikarModuleDb {
+  Future<Object> initModuleDaos();
+
+  Future<void> clearModule();
+}

--- a/lib/services/db/common/nepanikar_plan_form_dao.dart
+++ b/lib/services/db/common/nepanikar_plan_form_dao.dart
@@ -28,6 +28,10 @@ abstract class NepanikarPlanFormDao {
   Stream<List<RecordSnapshot<String, PlanFormItem?>>> get allFormItemsRecordsStream =>
       _store.query().onSnapshots(_db);
 
+  Future<void> doOldVersionMigration() async {
+    // TODO: implement doOldVersionMigration
+  }
+
   Future<void> clear() async {
     await _store.drop(_db);
   }

--- a/lib/services/db/depression/depression_module_db.dart
+++ b/lib/services/db/depression/depression_module_db.dart
@@ -1,0 +1,27 @@
+import 'package:nepanikar/services/db/common/nepanikar_module_db.dart';
+import 'package:nepanikar/services/db/database_service.dart';
+import 'package:nepanikar/services/db/depression/depression_activity_plan_dao.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class DepressionModuleDb implements NepanikarModuleDb {
+  DepressionModuleDb(this._dbService);
+
+  final DatabaseService _dbService;
+
+  late final DepressionActivityPlanDao _depressionActivityPlanDao;
+
+  @override
+  Future<DepressionModuleDb> initModuleDaos() async {
+    _depressionActivityPlanDao = await DepressionActivityPlanDao(dbService: _dbService).init();
+    return this;
+  }
+
+  @override
+  Future<void> clearModule() async {
+    await _depressionActivityPlanDao.clear();
+  }
+
+  Future<void> doModuleOldVersionMigration(NepanikarConfig moduleConfig) async {
+    // await _depressionActivityPlanDao.doOldVersionMigration(); // TODO
+  }
+}

--- a/lib/services/db/my_records/mood_track_dao.dart
+++ b/lib/services/db/my_records/mood_track_dao.dart
@@ -5,6 +5,7 @@ import 'package:nepanikar/services/db/database_service.dart';
 import 'package:nepanikar/services/db/filters.dart';
 import 'package:nepanikar/services/db/my_records/mood_track_model.dart';
 import 'package:nepanikar/utils/registry.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 import 'package:sembast/sembast.dart';
 
 class MoodTrackDao with CustomFilters {
@@ -73,6 +74,17 @@ class MoodTrackDao with CustomFilters {
           return null;
         }
       });
+
+  Future<void> doOldVersionMigration(MoodTrackDTO moodTrackConfig) async {
+    final valuesMap = moodTrackConfig.values;
+    for (final moodTrackEntry in valuesMap.entries) {
+      final mood = Mood.fromInteger(moodTrackEntry.value);
+      if (mood != null) {
+        final dateTime = moodTrackEntry.key;
+        await saveMood(mood, dateTime);
+      }
+    }
+  }
 
   Future<void> clear() async {
     await _store.drop(_db);

--- a/lib/services/db/my_records/my_records_module_db.dart
+++ b/lib/services/db/my_records/my_records_module_db.dart
@@ -1,0 +1,30 @@
+import 'package:nepanikar/services/db/common/nepanikar_module_db.dart';
+import 'package:nepanikar/services/db/database_service.dart';
+import 'package:nepanikar/services/db/my_records/mood_track_dao.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class MyRecordsModuleDb implements NepanikarModuleDb {
+  MyRecordsModuleDb(this._dbService);
+
+  final DatabaseService _dbService;
+
+  late final MoodTrackDao _moodTrackDao;
+
+  @override
+  Future<MyRecordsModuleDb> initModuleDaos() async {
+    _moodTrackDao = await MoodTrackDao(dbService: _dbService).init();
+    return this;
+  }
+
+  @override
+  Future<void> clearModule() async {
+    await _moodTrackDao.clear();
+  }
+
+  Future<void> doModuleOldVersionMigration(MyRecordsModuleDTO moduleConfig) async {
+    final moodTrackConfig = moduleConfig.moodTrackConfig;
+    if (moodTrackConfig != null) {
+      await _moodTrackDao.doOldVersionMigration(moodTrackConfig);
+    }
+  }
+}

--- a/lib/services/db/self_harm/self_harm_module_db.dart
+++ b/lib/services/db/self_harm/self_harm_module_db.dart
@@ -1,0 +1,40 @@
+import 'package:nepanikar/services/db/common/nepanikar_module_db.dart';
+import 'package:nepanikar/services/db/database_service.dart';
+import 'package:nepanikar/services/db/self_harm/self_harm_helped_dao.dart';
+import 'package:nepanikar/services/db/self_harm/self_harm_plan_dao.dart';
+import 'package:nepanikar/services/db/self_harm/self_harm_timer_dao.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class SelfHarmModuleDb implements NepanikarModuleDb {
+  SelfHarmModuleDb(this._dbService);
+
+  final DatabaseService _dbService;
+
+  late final SelfHarmPlanDao _selfHarmPlanDao;
+  late final SelfHarmTimerDao _selfHarmTimerDao;
+  late final SelfHarmHelpedDao _selfHarmHelpedDao;
+
+  @override
+  Future<SelfHarmModuleDb> initModuleDaos() async {
+    _selfHarmPlanDao = await SelfHarmPlanDao(dbService: _dbService).init();
+    _selfHarmTimerDao = await SelfHarmTimerDao(dbService: _dbService).init();
+    _selfHarmHelpedDao = await SelfHarmHelpedDao(dbService: _dbService).init();
+    return this;
+  }
+
+  @override
+  Future<void> clearModule() async {
+    await _selfHarmPlanDao.clear();
+    await _selfHarmTimerDao.clear();
+    await _selfHarmHelpedDao.clear();
+  }
+
+  Future<void> doModuleOldVersionMigration(SelfHarmModuleDTO moduleConfig) async {
+    // await _selfHarmPlanDao.doOldVersionMigration(); // TODO
+    final selfHarmTimerConfig = moduleConfig.selfHarmTimerConfig;
+    if (selfHarmTimerConfig != null) {
+      await _selfHarmTimerDao.doOldVersionMigration(selfHarmTimerConfig);
+    }
+    // await _selfHarmHelpedDao.doOldVersionMigration(); // TODO
+  }
+}

--- a/lib/services/db/self_harm/self_harm_timer_dao.dart
+++ b/lib/services/db/self_harm/self_harm_timer_dao.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nepanikar/services/db/database_service.dart';
 import 'package:nepanikar/utils/registry.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:sembast/sembast.dart';
 import 'package:sembast/timestamp.dart';
@@ -98,6 +99,22 @@ class SelfHarmTimerDao {
           return null;
         },
       );
+
+  Future<void> doOldVersionMigration(SelfHarmTimerDTO timerConfig) async {
+    if (timerConfig.currSelfHarmTimerStartDateTime != null) {
+      await startSelfHarmTimer(timerConfig.currSelfHarmTimerStartDateTime);
+    }
+
+    if (timerConfig.selfHarmTimerRecord != null) {
+      final nowUtc = DateTime.now().toUtc();
+      await saveNewBestRecord(
+        DateTimeRange(
+          start: nowUtc.subtract(Duration(seconds: timerConfig.selfHarmTimerRecord!)),
+          end: nowUtc,
+        ),
+      );
+    }
+  }
 
   Future<void> clear() async {
     await _store.drop(_db);

--- a/lib/services/db/suicidal_thoughts/suicidal_thoughts_module_db.dart
+++ b/lib/services/db/suicidal_thoughts/suicidal_thoughts_module_db.dart
@@ -1,0 +1,27 @@
+import 'package:nepanikar/services/db/common/nepanikar_module_db.dart';
+import 'package:nepanikar/services/db/database_service.dart';
+import 'package:nepanikar/services/db/suicidal_thoughts/suicidal_thoughts_plan_dao.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class SuicidalThoughtsModuleDb implements NepanikarModuleDb {
+  SuicidalThoughtsModuleDb(this._dbService);
+
+  final DatabaseService _dbService;
+
+  late final SuicidalThoughtsPlanDao _suicidalThoughtsPlanDao;
+
+  @override
+  Future<SuicidalThoughtsModuleDb> initModuleDaos() async {
+    _suicidalThoughtsPlanDao = await SuicidalThoughtsPlanDao(dbService: _dbService).init();
+    return this;
+  }
+
+  @override
+  Future<void> clearModule() async {
+    await _suicidalThoughtsPlanDao.clear();
+  }
+
+  Future<void> doModuleOldVersionMigration(NepanikarConfig moduleConfig) async {
+    // await _suicidalThoughtsPlanDao.doOldVersionMigration(); // TODO
+  }
+}


### PR DESCRIPTION
jen rozděleny ty daos zvlášt do modulů - každý dao bude mít clean, migraci a preload defaultních dat -- mít to vše v `db_services.dart` začínalo už být nepřehledné :D