### PR TITLE
fix: add external group name for Testflight

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -70,6 +70,7 @@ workflows:
       vars:
         MAJOR_VERSION: "2"
         MINOR_VERSION: "1"
+        TESTFLIGHT_EXTERNAL_GROUP_NAME: "App Store External Testing"
     scripts:
       # - *local_properties
       - *get_packages
@@ -82,6 +83,8 @@ workflows:
       app_store_connect:
         auth: integration
         submit_to_testflight: true
+        beta_groups:
+          - $TESTFLIGHT_EXTERNAL_GROUP_NAME
 
   dev:
     name: Development
@@ -98,6 +101,7 @@ workflows:
       vars:
         MAJOR_VERSION: "2"
         MINOR_VERSION: "0"
+        TESTFLIGHT_EXTERNAL_GROUP_NAME: "App Store External Testing"
     triggering:
       events:
         - push
@@ -118,3 +122,5 @@ workflows:
       app_store_connect:
         auth: integration
         submit_to_testflight: true
+        beta_groups:
+          - $TESTFLIGHT_EXTERNAL_GROUP_NAME


### PR DESCRIPTION
tohle hodí samo i do External Groupy v App Store Connect (jinak musely přidávat tam ty buildy manuálně)