### PR TITLE
feat: all data migrations (Android) (parsing logic only)

### DIFF
--- a/lib/services/db/my_records/mood_track_dao.dart
+++ b/lib/services/db/my_records/mood_track_dao.dart
@@ -75,13 +75,15 @@ class MoodTrackDao with CustomFilters {
         }
       });
 
-  Future<void> doOldVersionMigration(MoodTrackDTO moodTrackConfig) async {
+  Future<void> doOldVersionMigration(MyRecordsMoodTrackDTO moodTrackConfig) async {
     final valuesMap = moodTrackConfig.values;
-    for (final moodTrackEntry in valuesMap.entries) {
-      final mood = Mood.fromInteger(moodTrackEntry.value);
-      if (mood != null) {
-        final dateTime = moodTrackEntry.key;
-        await saveMood(mood, dateTime);
+    if (valuesMap != null) {
+      for (final moodTrackEntry in valuesMap.entries) {
+        final mood = Mood.fromInteger(moodTrackEntry.value);
+        if (mood != null) {
+          final dateTime = moodTrackEntry.key;
+          await saveMood(mood, dateTime);
+        }
       }
     }
   }

--- a/packages/nepanikar_data_migration/README.md
+++ b/packages/nepanikar_data_migration/README.md
@@ -1,1 +1,1 @@
-A simple package for managing the migation of data from the old Don't Panic app version.
+A simple package for managing the migration of data from the old Don't Panic app version.

--- a/packages/nepanikar_data_migration/bin/example_data/DontPanic_small.conf
+++ b/packages/nepanikar_data_migration/bin/example_data/DontPanic_small.conf
@@ -13,8 +13,8 @@ themeHue=0.76
 themeLight=-0.05
 
 [diaryRecords]
-1\value=26.9.2022|Testovaci zaznam - denik|$_^#_$
-2\value=26.10.2022|Testovaci zaznam - denik|$_^#_$
+1\value=25.12.2021|Testovaci zaznam - denik|$_^#_$
+2\value=2.8.2022|Testovaci zaznam2 - denik|$_^#_$
 size=2
 
 [foodAfraid]
@@ -55,7 +55,7 @@ size=1
 size=26
 
 [foodChallengeC]
-1\value=f
+1\value=t
 10\value=f
 11\value=f
 12\value=f
@@ -105,8 +105,8 @@ size=13
 11\value=f
 12\value=f
 13\value=f
-2\value=f
-3\value=f
+2\value=t
+3\value=t
 4\value=f
 5\value=f
 6\value=f
@@ -116,7 +116,7 @@ size=13
 size=13
 
 [foodFoodLike]
-1\value=
+1\value=eatingDisorderFoodILikeConfig
 size=1
 
 [foodFoodLikeC]
@@ -124,7 +124,7 @@ size=1
 size=1
 
 [foodLike]
-1\value=
+1\value=eatingDisorderFoodLikeOnMyselfConfig
 size=1
 
 [foodLikeC]
@@ -140,36 +140,42 @@ size=1
 size=1
 
 [foodRecordAmSnack]
-1\value=testovani jidla
+1\value=||||$_^#_$|0000000000|00000
 size=1
 
 [foodRecordBreakfast]
-1\value=testovani jidla
+1\value=||||$_^#_$|0000000000|00000
 size=1
 
 [foodRecordDates]
-1\value=testovani jidla
-size=1
+1\value=1.11.2022|-1|-1|1|-1|-1|-1
+2\value=23.12.2022|0|0|0|0|0|0
+3\value=25.12.2022|-1|-1|-1|1|-1|-1
+size=3
 
 [foodRecordDinner]
-1\value=testovani jidla
+1\value=||||$_^#_$|0000000000|00000
 size=1
 
 [foodRecordLunch]
-1\value=testovani jidla
-size=1
+1\value=||||$_^#_$|0000000000|00000
+2\value=kdy|kde|s k\xfdm |co|$_^#_$|0111100000|00110
+size=2
 
 [foodRecordPmSnack]
-1\value=testovani jidla
-size=1
+1\value=||||$_^#_$|0000000000|00000
+2\value=||||$_^#_$|0000000000|00000
+size=2
 
 [foodRecordSecondDinner]
-1\value=testovani jidla
+1\value=||||$_^#_$|0000000000|00000
+2\value=||||$_^#_$|0000000000|00000
 size=1
 
 [journalRecords]
-1\value=26.9.2022|Testovaci zaznam - journal|aa|bb|cc|neco|$_^#_$
-2\value=26.9.2022|Testovaci zaznam 2 - journal||bb|||$_^#_$
+1\value=17.12.2021|v\x161\x65\n vd\x11b\x10dn\xfd|ni\x10d\xedm |suprov\x11b|jidlo|uz|$_^#_$
+2\value=23.12.2022|hvvj|vvhj|vgu|hjib||$_^#_$
+3\value=25.12.2022||||||$_^#_$
 size=2
 
 [moods]

--- a/packages/nepanikar_data_migration/bin/nepanikar_data_migration.dart
+++ b/packages/nepanikar_data_migration/bin/nepanikar_data_migration.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print, unused_local_variable
 
 import 'dart:io';
 
@@ -15,12 +15,22 @@ Future<void> main(List<String> arguments) async {
   }
   const testStr = r'Zam\x11b\x159\xedm se na jin\xe9';
   const testStr2 = r'\x10dt pro 17 17:10:00 2020 GMT+0100';
-  print(testStr.cleanUnicodes());
-  print(testStr2.cleanUnicodes());
+  // print(testStr.cleanUnicodes());
+  // print(testStr2.cleanUnicodes());
 
   const filePath = './bin/example_data/DontPanic_small.conf';
   final conf = nep_data_migration.NepanikarConfigParser.parseConfigFile(File(filePath));
-  print(conf.toString());
+  print(
+    conf.myRecordsModuleConfig?.foodConfig?.records
+        .toString()
+        .replaceAll('FoodRecordDTO', '\n\nFoodRecordDTO'),
+  );
+
+  print('\n');
+  print(conf.depressionModuleConfig?.depressionActivityPlanConfig.toString());
+
+  print('\n');
+  print(conf.eatingDisorderModuleConfig?.eatingDisorderFoodCreativeConfig.toString());
 
   // const filePath2 = './bin/example_data/DontPanic_large.conf';
   // final conf2 = nep_data_migration.NepanikarConfigParser.parseConfigFile(File(filePath2));

--- a/packages/nepanikar_data_migration/lib/src/models/common/common.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/common/common.dart
@@ -1,0 +1,2 @@
+export 'package:nepanikar_data_migration/src/models/common/nepanikar_checklist_form_dto.dart';
+export 'package:nepanikar_data_migration/src/models/common/nepanikar_list_form_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/common/nepanikar_checklist_form_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/common/nepanikar_checklist_form_dto.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+/// List of text items with checkboxes.
+class NepanikarChecklistFormDTO extends Equatable {
+  const NepanikarChecklistFormDTO._({
+    required this.records,
+  });
+
+  factory NepanikarChecklistFormDTO.getData(
+    Config config, {
+    required String sectionTextsName,
+    required String sectionCheckboxStatesName,
+  }) {
+    final textsMap = config.itemsToMap(sectionTextsName);
+    final checkboxStatesMap = config.itemsToMap(sectionCheckboxStatesName);
+
+    final records = <MapEntry<String, bool>>[];
+    if (textsMap != null) {
+      final sortedTextEntries = textsMap.entries.toList()
+        ..sort((a, b) => confKeysSorter(a.key, b.key));
+
+      for (final textEntry in sortedTextEntries) {
+        final text = textEntry.value ?? '';
+        final checkboxState = checkboxStatesMap?[textEntry.key];
+        records.add(MapEntry(text, checkboxState?.getIniBoolValue() ?? false));
+      }
+    }
+
+    return NepanikarChecklistFormDTO._(
+      records: records.isEmpty ? null : records,
+    );
+  }
+
+  /// List of text items with checkboxes.
+  ///
+  /// Key is the text of the item, value is the checkbox state.
+  final Iterable<MapEntry<String, bool>>? records;
+
+  @override
+  List<Object?> get props => [records];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/common/nepanikar_list_form_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/common/nepanikar_list_form_dto.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+/// List of text items without checkboxes.
+class NepanikarListFormDTO extends Equatable {
+  const NepanikarListFormDTO._({
+    required this.texts,
+  });
+
+  factory NepanikarListFormDTO.getData(Config config, {required String sectionName}) {
+    final itemsMap = config.itemsToMap(sectionName);
+
+    final texts = <String>[];
+    if (itemsMap != null) {
+      final sortedKeys = itemsMap.keys.toList()..sort(confKeysSorter);
+      texts.addAll(sortedKeys.map((key) => itemsMap[key] ?? ''));
+    }
+
+    return NepanikarListFormDTO._(
+      texts: texts.isEmpty ? null : texts,
+    );
+  }
+
+  /// List of text items without checkboxes.
+  final List<String>? texts;
+
+  @override
+  List<Object?> get props => [texts];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/contacts/contacts.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/contacts/contacts.dart
@@ -1,0 +1,3 @@
+export 'package:nepanikar_data_migration/src/models/contacts/contacts_crisis_message_dto.dart';
+export 'package:nepanikar_data_migration/src/models/contacts/contacts_module_dto.dart';
+export 'package:nepanikar_data_migration/src/models/contacts/contacts_my_contacts_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_crisis_message_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_crisis_message_dto.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class ContactsCrisisMessageDTO extends Equatable {
+  const ContactsCrisisMessageDTO._({
+    required this.contactMessageAddress,
+    required this.contactMessageBody,
+  });
+
+  factory ContactsCrisisMessageDTO.getData(Config config) {
+    const sectionName = 'General';
+
+    final contactMessageAddress =
+        config.get(sectionName, 'contactMessageAddress')?.getIniStrValue();
+    final contactMessageBody = config.get(sectionName, 'contactMessageBody')?.getIniStrValue();
+
+    return ContactsCrisisMessageDTO._(
+      contactMessageAddress: contactMessageAddress,
+      contactMessageBody: contactMessageBody,
+    );
+  }
+
+  final String? contactMessageAddress;
+  final String? contactMessageBody;
+
+  @override
+  List<Object?> get props => [contactMessageAddress, contactMessageBody];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_module_dto.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class ContactsModuleDTO extends Equatable {
+  const ContactsModuleDTO._({
+    required this.contactsMyContactsConfig,
+    required this.contactsCrisisMessageConfig,
+  });
+
+  factory ContactsModuleDTO.getData(Config config) {
+    ContactsMyContactsDTO? contactsMyContactsConfig;
+    try {
+      contactsMyContactsConfig = ContactsMyContactsDTO.getData(config);
+    } catch (_) {}
+
+    ContactsCrisisMessageDTO? contactsCrisisMessageConfig;
+    try {
+      contactsCrisisMessageConfig = ContactsCrisisMessageDTO.getData(config);
+    } catch (_) {}
+
+    return ContactsModuleDTO._(
+      contactsMyContactsConfig: contactsMyContactsConfig,
+      contactsCrisisMessageConfig: contactsCrisisMessageConfig,
+    );
+  }
+
+  final ContactsMyContactsDTO? contactsMyContactsConfig;
+  final ContactsCrisisMessageDTO? contactsCrisisMessageConfig;
+
+  @override
+  List<Object?> get props => [contactsMyContactsConfig, contactsCrisisMessageConfig];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_my_contacts_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/contacts/contacts_my_contacts_dto.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class ContactsMyContactsDTO extends Equatable {
+  const ContactsMyContactsDTO._({
+    required this.myContactsEntries,
+  });
+
+  factory ContactsMyContactsDTO.getData(Config config) {
+    final myContactsNamesMap = config.itemsToMap('myContactsNames');
+    final myContactsNumbersMap = config.itemsToMap('myContactsNumbers');
+
+    final myContactsEntries = <MapEntry<String, String>>[];
+    if (myContactsNumbersMap != null) {
+      final sortedContactsNumbersMapEntries = myContactsNumbersMap.entries.toList()
+        ..sort((a, b) => confKeysSorter(a.key, b.key));
+
+      for (final contactNumberEntry in sortedContactsNumbersMapEntries) {
+        final name = myContactsNamesMap?[contactNumberEntry.key] ?? '';
+        final contact = contactNumberEntry.value ?? '';
+        myContactsEntries.add(MapEntry(name, contact));
+      }
+    }
+
+    return ContactsMyContactsDTO._(
+      myContactsEntries: myContactsEntries.isEmpty ? null : myContactsEntries,
+    );
+  }
+
+  /// Key is name of the contact, value is the phone number or email address.
+  final Iterable<MapEntry<String, String>>? myContactsEntries;
+
+  @override
+  List<Object?> get props => [myContactsEntries];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/depression/depression.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/depression/depression.dart
@@ -1,0 +1,1 @@
+export 'package:nepanikar_data_migration/src/models/depression/depression_module_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/depression/depression_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/depression/depression_module_dto.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class DepressionModuleDTO extends Equatable {
+  const DepressionModuleDTO._({
+    required this.depressionActivityPlanConfig,
+    required this.depressionNiceMadeHappyConfig,
+    required this.depressionPraiseMyAchievementsConfig,
+  });
+
+  factory DepressionModuleDTO.getData(Config config) {
+    NepanikarChecklistFormDTO? depressionActivityPlanConfig;
+    try {
+      depressionActivityPlanConfig = NepanikarChecklistFormDTO.getData(
+        config,
+        sectionTextsName: 'plan',
+        sectionCheckboxStatesName: 'planC',
+      );
+    } catch (_) {}
+
+    NepanikarListFormDTO? depressionNiceMadeHappyConfig;
+    try {
+      depressionNiceMadeHappyConfig = NepanikarListFormDTO.getData(config, sectionName: 'nice');
+    } catch (_) {}
+
+    NepanikarListFormDTO? depressionPraiseMyAchievementsConfig;
+    try {
+      depressionPraiseMyAchievementsConfig =
+          NepanikarListFormDTO.getData(config, sectionName: 'praise');
+    } catch (_) {}
+
+    return DepressionModuleDTO._(
+      depressionActivityPlanConfig: depressionActivityPlanConfig,
+      depressionNiceMadeHappyConfig: depressionNiceMadeHappyConfig,
+      depressionPraiseMyAchievementsConfig: depressionPraiseMyAchievementsConfig,
+    );
+  }
+
+  final NepanikarChecklistFormDTO? depressionActivityPlanConfig;
+  final NepanikarListFormDTO? depressionNiceMadeHappyConfig;
+  final NepanikarListFormDTO? depressionPraiseMyAchievementsConfig;
+
+  @override
+  List<Object?> get props => [
+        depressionActivityPlanConfig,
+        depressionNiceMadeHappyConfig,
+        depressionPraiseMyAchievementsConfig,
+      ];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/eating_disorder/eating_disorder.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/eating_disorder/eating_disorder.dart
@@ -1,0 +1,1 @@
+export 'package:nepanikar_data_migration/src/models/eating_disorder/eating_disorder_module_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/eating_disorder/eating_disorder_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/eating_disorder/eating_disorder_module_dto.dart
@@ -1,0 +1,90 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class EatingDisorderModuleDTO extends Equatable {
+  const EatingDisorderModuleDTO._({
+    required this.eatingDisorderFoodCreativeConfig,
+    required this.eatingDisorderFoodMotivationConfig,
+    required this.eatingDisorderFoodChallengesConfig,
+    required this.eatingDisorderFoodLikeOnMyselfConfig,
+    required this.eatingDisorderFoodILikeConfig,
+    required this.eatingDisorderFoodAfraidOfConfig,
+  });
+
+  factory EatingDisorderModuleDTO.getData(Config config) {
+    NepanikarChecklistFormDTO? eatingDisorderFoodCreativeConfig;
+    try {
+      eatingDisorderFoodCreativeConfig = NepanikarChecklistFormDTO.getData(
+        config,
+        sectionTextsName: 'foodCreative',
+        sectionCheckboxStatesName: 'foodCreativeC',
+      );
+    } catch (_) {}
+
+    NepanikarChecklistFormDTO? eatingDisorderFoodMotivationConfig;
+    try {
+      eatingDisorderFoodMotivationConfig = NepanikarChecklistFormDTO.getData(
+        config,
+        sectionTextsName: 'foodMotivation',
+        sectionCheckboxStatesName: 'foodMotivationC',
+      );
+    } catch (_) {}
+
+    NepanikarChecklistFormDTO? eatingDisorderFoodChallengesConfig;
+    try {
+      eatingDisorderFoodChallengesConfig = NepanikarChecklistFormDTO.getData(
+        config,
+        sectionTextsName: 'foodChallenge',
+        sectionCheckboxStatesName: 'foodChallengeC',
+      );
+    } catch (_) {}
+
+    NepanikarListFormDTO? eatingDisorderFoodLikeOnMyselfConfig;
+    try {
+      eatingDisorderFoodLikeOnMyselfConfig =
+          NepanikarListFormDTO.getData(config, sectionName: 'foodLike');
+    } catch (_) {}
+
+    NepanikarListFormDTO? eatingDisorderFoodILikeConfig;
+    try {
+      eatingDisorderFoodILikeConfig =
+          NepanikarListFormDTO.getData(config, sectionName: 'foodFoodLike');
+    } catch (_) {}
+
+    NepanikarChecklistFormDTO? eatingDisorderFoodAfraidOfConfig;
+    try {
+      eatingDisorderFoodAfraidOfConfig = NepanikarChecklistFormDTO.getData(
+        config,
+        sectionTextsName: 'foodAfraid',
+        sectionCheckboxStatesName: 'foodAfraidC',
+      );
+    } catch (_) {}
+
+    return EatingDisorderModuleDTO._(
+      eatingDisorderFoodCreativeConfig: eatingDisorderFoodCreativeConfig,
+      eatingDisorderFoodMotivationConfig: eatingDisorderFoodMotivationConfig,
+      eatingDisorderFoodChallengesConfig: eatingDisorderFoodChallengesConfig,
+      eatingDisorderFoodLikeOnMyselfConfig: eatingDisorderFoodLikeOnMyselfConfig,
+      eatingDisorderFoodILikeConfig: eatingDisorderFoodILikeConfig,
+      eatingDisorderFoodAfraidOfConfig: eatingDisorderFoodAfraidOfConfig,
+    );
+  }
+
+  final NepanikarChecklistFormDTO? eatingDisorderFoodCreativeConfig;
+  final NepanikarChecklistFormDTO? eatingDisorderFoodMotivationConfig;
+  final NepanikarChecklistFormDTO? eatingDisorderFoodChallengesConfig;
+  final NepanikarListFormDTO? eatingDisorderFoodLikeOnMyselfConfig;
+  final NepanikarListFormDTO? eatingDisorderFoodILikeConfig;
+  final NepanikarChecklistFormDTO? eatingDisorderFoodAfraidOfConfig;
+
+  @override
+  List<Object?> get props => [
+        eatingDisorderFoodCreativeConfig,
+        eatingDisorderFoodMotivationConfig,
+        eatingDisorderFoodChallengesConfig,
+        eatingDisorderFoodLikeOnMyselfConfig,
+        eatingDisorderFoodILikeConfig,
+        eatingDisorderFoodAfraidOfConfig,
+      ];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/models.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/models.dart
@@ -1,3 +1,8 @@
+export 'package:nepanikar_data_migration/src/models/common/common.dart';
+export 'package:nepanikar_data_migration/src/models/contacts/contacts.dart';
+export 'package:nepanikar_data_migration/src/models/depression/depression.dart';
+export 'package:nepanikar_data_migration/src/models/eating_disorder/eating_disorder.dart';
 export 'package:nepanikar_data_migration/src/models/my_records/my_records.dart';
 export 'package:nepanikar_data_migration/src/models/nepanikar_config.dart';
 export 'package:nepanikar_data_migration/src/models/self_harm/self_harm.dart';
+export 'package:nepanikar_data_migration/src/models/suicidal_thoughts/suicidal_thoughts.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records.dart
@@ -1,2 +1,6 @@
-export 'package:nepanikar_data_migration/src/models/my_records/mood_track_dto.dart';
+export 'package:nepanikar_data_migration/src/models/my_records/my_records_diary_dto.dart';
+export 'package:nepanikar_data_migration/src/models/my_records/my_records_food_dto.dart';
+export 'package:nepanikar_data_migration/src/models/my_records/my_records_journal_dto.dart';
 export 'package:nepanikar_data_migration/src/models/my_records/my_records_module_dto.dart';
+export 'package:nepanikar_data_migration/src/models/my_records/my_records_mood_track_dto.dart';
+export 'package:nepanikar_data_migration/src/models/my_records/my_records_sleep_track_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_diary_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_diary_dto.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class MyRecordsDiaryDTO extends Equatable {
+  const MyRecordsDiaryDTO._({
+    required this.recordEntries,
+  });
+
+  factory MyRecordsDiaryDTO.getData(Config config) {
+    const sectionName = 'diaryRecords';
+
+    final recordEntries = <MapEntry<DateTime, String>>[];
+    final confLines = config.items(sectionName);
+
+    if (confLines != null) {
+      for (final confLine in confLines) {
+        if (confLine.length == 2) {
+          final key = confLine[0];
+          final values = confLine[1];
+          if (key != null && values != null && key.contains('value')) {
+            final splitValues = values.split('|');
+            if (splitValues.length >= 2) {
+              final date = splitValues[0].getIniDateTimeValue(
+                    cleanFromUnicodes: false,
+                    dateTimePattern: NepanikarConfigParser.QT_DATE_PATTERN,
+                  ) ??
+                  DateTime(2000);
+              final text = splitValues[1].getIniStrValue() ?? '';
+              recordEntries.add(MapEntry(date, text));
+            }
+          }
+        }
+      }
+    }
+
+    return MyRecordsDiaryDTO._(
+      recordEntries: recordEntries.isEmpty ? null : recordEntries,
+    );
+  }
+
+  /// Key is the date, value is the text.
+  final List<MapEntry<DateTime, String>>? recordEntries;
+
+  @override
+  List<Object?> get props => [recordEntries];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_food_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_food_dto.dart
@@ -1,0 +1,188 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+import 'package:tuple/tuple.dart';
+
+enum FoodType { breakfast, amSnack, lunch, pmSnack, dinner, secondDinner }
+
+enum FoodQuestionText { when, where, $with, what }
+
+enum FoodQuestionFeel {
+  happy,
+  satisfied,
+  proud,
+  fear,
+  anger,
+  anxiety,
+  unsatisfied,
+  disgusted,
+  sad,
+  stress,
+}
+
+enum FoodQuestionProblem { vomit, exercise, selfHarm, laxative, anxietyAttack }
+
+class FoodRecordAnswerDTO extends Equatable {
+  const FoodRecordAnswerDTO({
+    required this.foodType,
+    required this.textQuestionAnswers,
+    required this.feelTickedAnswers,
+    required this.problemTickedAnswers,
+  });
+
+  final FoodType foodType;
+  final List<Tuple2<FoodQuestionText, String>> textQuestionAnswers;
+  final List<FoodQuestionFeel> feelTickedAnswers;
+  final List<FoodQuestionProblem> problemTickedAnswers;
+
+  @override
+  List<Object> get props =>
+      [foodType, textQuestionAnswers, feelTickedAnswers, problemTickedAnswers];
+
+  @override
+  String toString() {
+    return 'FoodRecordAnswerDTO(foodType: $foodType, textQuestionAnswers: $textQuestionAnswers, feelTickedAnswers: $feelTickedAnswers, problemTickedAnswers: $problemTickedAnswers)';
+  }
+}
+
+class FoodRecordDTO extends Equatable {
+  const FoodRecordDTO({
+    required this.date,
+    required this.answers,
+  });
+
+  final DateTime date;
+  final List<FoodRecordAnswerDTO> answers;
+
+  @override
+  List<Object> get props => [date, answers];
+}
+
+class MyRecordsFoodDTO extends Equatable {
+  const MyRecordsFoodDTO._({
+    required this.records,
+  });
+
+  factory MyRecordsFoodDTO.getData(Config config) {
+    final records = <FoodRecordDTO>[];
+
+    final foodRecordsDateMap = config.itemsToMap('foodRecordDates');
+
+    final foodTypeBreakfastMap = config.itemsToMap('foodRecordBreakfast');
+    final foodTypeAmSnackMap = config.itemsToMap('foodRecordAmSnack');
+    final foodTypeLunchMap = config.itemsToMap('foodRecordLunch');
+    final foodTypePmSnackMap = config.itemsToMap('foodRecordPmSnack');
+    final foodTypeDinnerMap = config.itemsToMap('foodRecordDinner');
+    final foodTypeSecondDinnerMap = config.itemsToMap('foodRecordSecondDinner');
+
+    FoodRecordAnswerDTO getFoodRecordAnswer({
+      required FoodType foodType,
+      required String? dataConfigLine,
+    }) {
+      final textQuestionAnswers = <Tuple2<FoodQuestionText, String>>[];
+      final feelTickedAnswers = <FoodQuestionFeel>[];
+      final problemTickedAnswers = <FoodQuestionProblem>[];
+
+      if (dataConfigLine == null) {
+        return FoodRecordAnswerDTO(
+          foodType: foodType,
+          textQuestionAnswers: textQuestionAnswers,
+          feelTickedAnswers: feelTickedAnswers,
+          problemTickedAnswers: problemTickedAnswers,
+        );
+      }
+
+      final dataConfigLineParts = dataConfigLine.split('|');
+      if (dataConfigLineParts.length >= 6) {
+        for (final foodTextQuestion in FoodQuestionText.values) {
+          if (foodTextQuestion.index < 4) {
+            final answer = dataConfigLineParts.elementAtOrNull(foodTextQuestion.index);
+            textQuestionAnswers.add(Tuple2(foodTextQuestion, answer ?? ''));
+          }
+        }
+
+        for (final feelAnswer in FoodQuestionFeel.values) {
+          final answer = dataConfigLineParts.elementAtOrNull(5);
+          if (answer != null && answer.length == 10) {
+            final answerBool = answer.split('').elementAtOrNull(feelAnswer.index);
+            if (answerBool == '1') {
+              feelTickedAnswers.add(feelAnswer);
+            }
+          }
+        }
+
+        for (final problemAnswer in FoodQuestionProblem.values) {
+          final answer = dataConfigLineParts.elementAtOrNull(6);
+          if (answer != null && answer.length == 5) {
+            final answerBool = answer.split('').elementAtOrNull(problemAnswer.index);
+            if (answerBool == '1') {
+              problemTickedAnswers.add(problemAnswer);
+            }
+          }
+        }
+      }
+
+      return FoodRecordAnswerDTO(
+        foodType: foodType,
+        textQuestionAnswers: textQuestionAnswers,
+        feelTickedAnswers: feelTickedAnswers,
+        problemTickedAnswers: problemTickedAnswers,
+      );
+    }
+
+    if (foodRecordsDateMap != null) {
+      for (final record in foodRecordsDateMap.entries) {
+        if (record.value == null) continue;
+        final splitValues = record.value!.split('|');
+        if (splitValues.isNotEmpty) {
+          final date = splitValues.first.getIniDateTimeValue(
+                cleanFromUnicodes: false,
+                dateTimePattern: NepanikarConfigParser.QT_DATE_PATTERN,
+              ) ??
+              DateTime(2000);
+
+          final answers = <FoodRecordAnswerDTO>[];
+          answers.addAll(
+            [
+              getFoodRecordAnswer(
+                foodType: FoodType.breakfast,
+                dataConfigLine: foodTypeBreakfastMap?[record.key],
+              ),
+              getFoodRecordAnswer(
+                foodType: FoodType.amSnack,
+                dataConfigLine: foodTypeAmSnackMap?[record.key],
+              ),
+              getFoodRecordAnswer(
+                foodType: FoodType.lunch,
+                dataConfigLine: foodTypeLunchMap?[record.key],
+              ),
+              getFoodRecordAnswer(
+                foodType: FoodType.pmSnack,
+                dataConfigLine: foodTypePmSnackMap?[record.key],
+              ),
+              getFoodRecordAnswer(
+                foodType: FoodType.dinner,
+                dataConfigLine: foodTypeDinnerMap?[record.key],
+              ),
+              getFoodRecordAnswer(
+                foodType: FoodType.secondDinner,
+                dataConfigLine: foodTypeSecondDinnerMap?[record.key],
+              ),
+            ],
+          );
+
+          records.add(FoodRecordDTO(date: date, answers: answers));
+        }
+      }
+    }
+
+    return MyRecordsFoodDTO._(
+      records: records.isEmpty ? null : records,
+    );
+  }
+
+  final List<FoodRecordDTO>? records;
+
+  @override
+  List<Object?> get props => [records];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_journal_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_journal_dto.dart
@@ -1,0 +1,68 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+import 'package:tuple/tuple.dart';
+
+enum JournalQuestion { grateful, great, feel, three, improve }
+
+class JournalRecordDTO extends Equatable {
+  const JournalRecordDTO({
+    required this.date,
+    required this.answers,
+  });
+
+  final DateTime date;
+  final List<Tuple2<JournalQuestion, String>> answers;
+
+  @override
+  List<Object> get props => [date, answers];
+}
+
+class MyRecordsJournalDTO extends Equatable {
+  const MyRecordsJournalDTO._({
+    required this.records,
+  });
+
+  factory MyRecordsJournalDTO.getData(Config config) {
+    const sectionName = 'journalRecords';
+
+    final records = <JournalRecordDTO>[];
+    final confLines = config.items(sectionName);
+
+    if (confLines != null) {
+      for (final confLine in confLines) {
+        if (confLine.length == 2) {
+          final key = confLine[0];
+          final values = confLine[1];
+          if (key != null && values != null && key.contains('value')) {
+            final splitValues = values.split('|');
+            if (splitValues.length >= 6) {
+              final date = splitValues[0].getIniDateTimeValue(
+                    cleanFromUnicodes: false,
+                    dateTimePattern: NepanikarConfigParser.QT_DATE_PATTERN,
+                  ) ??
+                  DateTime(2000);
+              final answers = <Tuple2<JournalQuestion, String>>[];
+              for (final journalQuestion in JournalQuestion.values) {
+                // First item is the date, so we need to add 1 to the index.
+                final answer =
+                    splitValues.elementAtOrNull(journalQuestion.index + 1)?.getIniStrValue() ?? '';
+                answers.add(Tuple2(journalQuestion, answer));
+              }
+              records.add(JournalRecordDTO(date: date, answers: answers));
+            }
+          }
+        }
+      }
+    }
+
+    return MyRecordsJournalDTO._(
+      records: records.isEmpty ? null : records,
+    );
+  }
+
+  final List<JournalRecordDTO>? records;
+
+  @override
+  List<Object?> get props => [records];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_module_dto.dart
@@ -1,24 +1,63 @@
 import 'package:equatable/equatable.dart';
 import 'package:ini/ini.dart';
-import 'package:nepanikar_data_migration/src/models/my_records/mood_track_dto.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 
 class MyRecordsModuleDTO extends Equatable {
   const MyRecordsModuleDTO._({
     required this.moodTrackConfig,
+    required this.sleepTrackConfig,
+    required this.diaryConfig,
+    required this.journalConfig,
+    required this.foodConfig,
   });
 
   factory MyRecordsModuleDTO.getData(Config config) {
-    MoodTrackDTO? moodTrackConfig;
+    MyRecordsMoodTrackDTO? moodTrackConfig;
     try {
-      moodTrackConfig = MoodTrackDTO.getData(config);
+      moodTrackConfig = MyRecordsMoodTrackDTO.getData(config);
     } catch (_) {}
+
+    MyRecordsSleepTrackDTO? sleepTrackConfig;
+    try {
+      sleepTrackConfig = MyRecordsSleepTrackDTO.getData(config);
+    } catch (_) {}
+
+    MyRecordsDiaryDTO? diaryConfig;
+    try {
+      diaryConfig = MyRecordsDiaryDTO.getData(config);
+    } catch (_) {}
+
+    MyRecordsJournalDTO? journalConfig;
+    try {
+      journalConfig = MyRecordsJournalDTO.getData(config);
+    } catch (_) {}
+
+    MyRecordsFoodDTO? foodConfig;
+    try {
+      foodConfig = MyRecordsFoodDTO.getData(config);
+    } catch (_) {}
+
     return MyRecordsModuleDTO._(
       moodTrackConfig: moodTrackConfig,
+      sleepTrackConfig: sleepTrackConfig,
+      diaryConfig: diaryConfig,
+      journalConfig: journalConfig,
+      foodConfig: foodConfig,
     );
   }
 
-  final MoodTrackDTO? moodTrackConfig;
+  final MyRecordsMoodTrackDTO? moodTrackConfig;
+  final MyRecordsSleepTrackDTO? sleepTrackConfig;
+  final MyRecordsDiaryDTO? diaryConfig;
+  final MyRecordsJournalDTO? journalConfig;
+  final MyRecordsFoodDTO? foodConfig;
 
   @override
-  List<Object?> get props => [moodTrackConfig];
+  List<Object?> get props => [
+        moodTrackConfig,
+        sleepTrackConfig,
+        diaryConfig,
+        journalConfig,
+        foodConfig,
+      ];
 }

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_mood_track_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_mood_track_dto.dart
@@ -2,17 +2,16 @@ import 'package:equatable/equatable.dart';
 import 'package:ini/ini.dart';
 import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 
-class MoodTrackDTO extends Equatable {
-  const MoodTrackDTO._({
+class MyRecordsMoodTrackDTO extends Equatable {
+  const MyRecordsMoodTrackDTO._({
     required this.values,
   });
 
-  factory MoodTrackDTO.getData(Config config) {
-    const sectionName = 'moods';
-
+  factory MyRecordsMoodTrackDTO.getData(Config config, {String sectionName = 'moods'}) {
     final convertedValues = <DateTime, int>{};
     final confValues = config.items(sectionName);
-    if (confValues != null && confValues.isNotEmpty) {
+
+    if (confValues != null) {
       for (final item in confValues) {
         if (item.length == 2) {
           final key = item[0];
@@ -31,16 +30,16 @@ class MoodTrackDTO extends Equatable {
         }
       }
     }
-    return MoodTrackDTO._(
-      values: convertedValues,
+    return MyRecordsMoodTrackDTO._(
+      values: convertedValues.isEmpty ? null : convertedValues,
     );
   }
 
   /// The map of mood track values.
   ///
   /// Key is the date, value is the mood (0 - sad, 4 happy).
-  final Map<DateTime, int> values;
+  final Map<DateTime, int>? values;
 
   @override
-  List<Object> get props => [values];
+  List<Object?> get props => [values];
 }

--- a/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_sleep_track_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_sleep_track_dto.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class MyRecordsSleepTrackDTO extends Equatable {
+  const MyRecordsSleepTrackDTO._({
+    required this.values,
+  });
+
+  factory MyRecordsSleepTrackDTO.getData(Config config) {
+    final values = MyRecordsMoodTrackDTO.getData(config, sectionName: 'sleep').values;
+    return MyRecordsSleepTrackDTO._(
+      values: values == null || values.isEmpty ? null : values,
+    );
+  }
+
+  /// The map of sleep track values.
+  ///
+  /// Key is the date, value is the mood (0 - sad, 4 happy).
+  final Map<DateTime, int>? values;
+
+  @override
+  List<Object?> get props => [values];
+}

--- a/packages/nepanikar_data_migration/lib/src/models/nepanikar_config.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/nepanikar_config.dart
@@ -4,14 +4,33 @@ import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 
 class NepanikarConfig extends Equatable {
   const NepanikarConfig._({
+    required this.depressionModuleConfig,
     required this.selfHarmModuleConfig,
+    required this.suicidalThoughtsModuleConfig,
+    required this.eatingDisorderModuleConfig,
     required this.myRecordsModuleConfig,
+    required this.contactsModuleConfig,
   });
 
   factory NepanikarConfig.getData(Config config) {
+    DepressionModuleDTO? depressionModuleConfig;
+    try {
+      depressionModuleConfig = DepressionModuleDTO.getData(config);
+    } catch (_) {}
+
     SelfHarmModuleDTO? selfHarmModuleConfig;
     try {
       selfHarmModuleConfig = SelfHarmModuleDTO.getData(config);
+    } catch (_) {}
+
+    SuicidalThoughtsModuleDTO? suicidalThoughtsModuleConfig;
+    try {
+      suicidalThoughtsModuleConfig = SuicidalThoughtsModuleDTO.getData(config);
+    } catch (_) {}
+
+    EatingDisorderModuleDTO? eatingDisorderModuleConfig;
+    try {
+      eatingDisorderModuleConfig = EatingDisorderModuleDTO.getData(config);
     } catch (_) {}
 
     MyRecordsModuleDTO? myRecordsModuleConfig;
@@ -19,15 +38,35 @@ class NepanikarConfig extends Equatable {
       myRecordsModuleConfig = MyRecordsModuleDTO.getData(config);
     } catch (_) {}
 
+    ContactsModuleDTO? contactsModuleConfig;
+    try {
+      contactsModuleConfig = ContactsModuleDTO.getData(config);
+    } catch (_) {}
+
     return NepanikarConfig._(
+      depressionModuleConfig: depressionModuleConfig,
       selfHarmModuleConfig: selfHarmModuleConfig,
+      suicidalThoughtsModuleConfig: suicidalThoughtsModuleConfig,
+      eatingDisorderModuleConfig: eatingDisorderModuleConfig,
       myRecordsModuleConfig: myRecordsModuleConfig,
+      contactsModuleConfig: contactsModuleConfig,
     );
   }
 
+  final DepressionModuleDTO? depressionModuleConfig;
   final SelfHarmModuleDTO? selfHarmModuleConfig;
+  final SuicidalThoughtsModuleDTO? suicidalThoughtsModuleConfig;
+  final EatingDisorderModuleDTO? eatingDisorderModuleConfig;
   final MyRecordsModuleDTO? myRecordsModuleConfig;
+  final ContactsModuleDTO? contactsModuleConfig;
 
   @override
-  List<Object?> get props => [selfHarmModuleConfig, myRecordsModuleConfig];
+  List<Object?> get props => [
+        depressionModuleConfig,
+        selfHarmModuleConfig,
+        suicidalThoughtsModuleConfig,
+        eatingDisorderModuleConfig,
+        myRecordsModuleConfig,
+        contactsModuleConfig,
+      ];
 }

--- a/packages/nepanikar_data_migration/lib/src/models/self_harm/self_harm_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/self_harm/self_harm_module_dto.dart
@@ -4,21 +4,37 @@ import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
 
 class SelfHarmModuleDTO extends Equatable {
   const SelfHarmModuleDTO._({
+    required this.selfHarmHelpedConfig,
+    required this.selfHarmPlanConfig,
     required this.selfHarmTimerConfig,
   });
 
   factory SelfHarmModuleDTO.getData(Config config) {
+    NepanikarListFormDTO? selfHarmHelpedConfig;
+    try {
+      selfHarmHelpedConfig = NepanikarListFormDTO.getData(config, sectionName: 'selfHarmHelped');
+    } catch (_) {}
+
+    NepanikarListFormDTO? selfHarmPlanConfig;
+    try {
+      selfHarmPlanConfig = NepanikarListFormDTO.getData(config, sectionName: 'selfHarmPlan');
+    } catch (_) {}
+
     SelfHarmTimerDTO? selfHarmTimerConfig;
     try {
       selfHarmTimerConfig = SelfHarmTimerDTO.getData(config);
     } catch (_) {}
     return SelfHarmModuleDTO._(
+      selfHarmHelpedConfig: selfHarmHelpedConfig,
+      selfHarmPlanConfig: selfHarmPlanConfig,
       selfHarmTimerConfig: selfHarmTimerConfig,
     );
   }
 
+  final NepanikarListFormDTO? selfHarmHelpedConfig;
+  final NepanikarListFormDTO? selfHarmPlanConfig;
   final SelfHarmTimerDTO? selfHarmTimerConfig;
 
   @override
-  List<Object?> get props => [selfHarmTimerConfig];
+  List<Object?> get props => [selfHarmHelpedConfig, selfHarmPlanConfig, selfHarmTimerConfig];
 }

--- a/packages/nepanikar_data_migration/lib/src/models/suicidal_thoughts/suicidal_thoughts.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/suicidal_thoughts/suicidal_thoughts.dart
@@ -1,0 +1,1 @@
+export 'package:nepanikar_data_migration/src/models/suicidal_thoughts/suicidal_thoughts_module_dto.dart';

--- a/packages/nepanikar_data_migration/lib/src/models/suicidal_thoughts/suicidal_thoughts_module_dto.dart
+++ b/packages/nepanikar_data_migration/lib/src/models/suicidal_thoughts/suicidal_thoughts_module_dto.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import 'package:ini/ini.dart';
+import 'package:nepanikar_data_migration/nepanikar_data_migration.dart';
+
+class SuicidalThoughtsModuleDTO extends Equatable {
+  const SuicidalThoughtsModuleDTO._({
+    required this.suicidalThoughtsPlanConfig,
+    required this.suicidalThoughtsReasonsNoConfig,
+  });
+
+  factory SuicidalThoughtsModuleDTO.getData(Config config) {
+    NepanikarListFormDTO? suicidalThoughtsPlanConfig;
+    try {
+      suicidalThoughtsPlanConfig = NepanikarListFormDTO.getData(config, sectionName: 'suicidePlan');
+    } catch (_) {}
+
+    NepanikarListFormDTO? suicidalThoughtsReasonsNoConfig;
+    try {
+      suicidalThoughtsReasonsNoConfig =
+          NepanikarListFormDTO.getData(config, sectionName: 'reasons');
+    } catch (_) {}
+
+    return SuicidalThoughtsModuleDTO._(
+      suicidalThoughtsPlanConfig: suicidalThoughtsPlanConfig,
+      suicidalThoughtsReasonsNoConfig: suicidalThoughtsReasonsNoConfig,
+    );
+  }
+
+  final NepanikarListFormDTO? suicidalThoughtsPlanConfig;
+  final NepanikarListFormDTO? suicidalThoughtsReasonsNoConfig;
+
+  @override
+  List<Object?> get props => [
+        suicidalThoughtsPlanConfig,
+        suicidalThoughtsReasonsNoConfig,
+      ];
+}

--- a/packages/nepanikar_data_migration/lib/src/parser/iterable_helpers.dart
+++ b/packages/nepanikar_data_migration/lib/src/parser/iterable_helpers.dart
@@ -1,0 +1,11 @@
+import 'package:collection/collection.dart';
+
+// TODO: Taken from https://github.com/dart-lang/collection/pull/217 but can not use yet due to
+// dependency conflict.
+extension IterableExtension<T> on Iterable<T> {
+  T? elementAtOrNull(int index) => skip(index).firstOrNull;
+}
+
+extension ListExtensions<E> on List<E> {
+  E? elementAtOrNull(int index) => (index < length) ? this[index] : null;
+}

--- a/packages/nepanikar_data_migration/lib/src/parser/parser.dart
+++ b/packages/nepanikar_data_migration/lib/src/parser/parser.dart
@@ -1,1 +1,2 @@
+export 'package:nepanikar_data_migration/src/parser/iterable_helpers.dart';
 export 'package:nepanikar_data_migration/src/parser/nepanikar_config_parser.dart';

--- a/packages/nepanikar_data_migration/pubspec.lock
+++ b/packages/nepanikar_data_migration/pubspec.lock
@@ -309,6 +309,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.20"
+  tuple:
+    dependency: "direct main"
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/packages/nepanikar_data_migration/pubspec.yaml
+++ b/packages/nepanikar_data_migration/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nepanikar_data_migration
-description: A simple package for managing the migation of data from the old Don't Panic app version.
+description: A simple package for managing the migration of data from the old Don't Panic app version.
 version: 1.0.0
 publish_to: 'none'
 
@@ -11,6 +11,7 @@ dependencies:
   equatable: ^2.0.5
   ini: ^2.1.0
   intl: ^0.17.0
+  tuple: ^2.0.1
 
 dev_dependencies:
   lint: ^1.10.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -824,6 +824,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
migrace pro všechny moduly na konfig ze staré verze - jen úprava v package a ještě se musí upravit ten migration kod v databazich v appce, tak to udělám v nějakým navazovacím PR a toto merguju.

Dá se testovat přes example cmd appku v tom `packages/nepanikar_data_migration`

Nejhorší bylo to Záznam jídelníčku https://github.com/cesko-digital/nepanikar/blob/8feb33c11d1a5ee2941d925300eff4bda35b2d15/packages/nepanikar_data_migration/lib/src/models/my_records/my_records_food_dto.dart, je to clekem hacky takhle parsovat, ale mělo by to být funkční. Ještě že je GitHub Copilot který je vhodnej na takovou repete práci :D