### PR TITLE
fix: intl preload crash

### DIFF
--- a/lib/utils/app_setup.dart
+++ b/lib/utils/app_setup.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+// ignore: implementation_imports
+import 'package:flutter_localizations/src/utils/date_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nepanikar/app/router/go_router_config.dart';
 import 'package:nepanikar/firebase_options.dart';
@@ -36,9 +36,7 @@ Future<void> setup() async {
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(!kDebugMode);
 
   // Initialize intl localizations.
-  for (final delegate in AppLocalizations.localizationsDelegates) {
-    await delegate.load(ui.Locale(ui.window.locale.languageCode));
-  }
+  loadDateIntlDataIfNotLoaded();
 
   // router
   registry.registerSingleton<GoRouter>(goRouterConfig);


### PR DESCRIPTION
už ojbevil první crash ve Firebase https://console.firebase.google.com/u/0/project/nepanikar-cad6d/crashlytics/app/ios:org.dontpanicapp/issues/b393d65c52801f6e645cc4b27202a82c?time=last-seven-days&sessionEventKey=452dea6a330d4f65b9a08f864cb01eb2_1763727660173037415

tamta metoda předtím ~~actaully nedělala nic~~ preloadovalo jen jazyky které jsou v te ./arb složce, kde čínština neni
jinde jsme našel že se má dělat přes: `initializeDateFormatting()` jenže to taky crashovalo appku při startupu

tohle vypadá že funguje