### PR TITLE
hotfix: backup data from old app during migration, parsing fixes

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -80,7 +80,7 @@ workflows:
         bundle_identifier: org.dontpanicapp
       vars:
         MAJOR_VERSION: "2"
-        MINOR_VERSION: "2"
+        MINOR_VERSION: "4"
         TESTFLIGHT_EXTERNAL_GROUP_NAME: "App Store External Testing"
     scripts:
       - *local_properties
@@ -118,7 +118,7 @@ workflows:
         bundle_identifier: org.dontpanicapp
       vars:
         MAJOR_VERSION: "2"
-        MINOR_VERSION: "2"
+        MINOR_VERSION: "3"
         TESTFLIGHT_EXTERNAL_GROUP_NAME: "App Store External Testing"
     triggering:
       events:

--- a/lib/services/save_directories.dart
+++ b/lib/services/save_directories.dart
@@ -21,6 +21,8 @@ class SaveDirectories {
   String get oldAppDataConfigFilePath =>
       join(supportDir.path, '.config', 'DontPanicDevs', 'DontPanic.conf');
 
+  String get oldAppDataConfigFileBackupPath => join(supportDir.path, 'DontPanicOldConfig');
+
   Future<void> clearSaveDirectories() async {
     try {
       await supportDir.delete(recursive: true);

--- a/packages/nepanikar_data_migration/bin/nepanikar_data_migration.dart
+++ b/packages/nepanikar_data_migration/bin/nepanikar_data_migration.dart
@@ -10,7 +10,7 @@ Future<void> main(List<String> arguments) async {
   // final a = codec.encode(testStr);
   // final ab = codec.decode(a);
 
-  for (final locale in nep_data_migration.NepanikarConfigParser.fallbackParseLocale) {
+  for (final locale in nep_data_migration.fallbackParseLocales) {
     await initializeDateFormatting(locale);
   }
   const testStr = r'Zam\x11b\x159\xedm se na jin\xe9';

--- a/packages/nepanikar_data_migration/lib/src/parser/nepanikar_config_parser.dart
+++ b/packages/nepanikar_data_migration/lib/src/parser/nepanikar_config_parser.dart
@@ -18,8 +18,6 @@ class NepanikarConfigParser {
 
   static const QT_DATE_PATTERN = 'd.M.yyyy';
 
-  static final fallbackParseLocale = ['cs', 'en'];
-
   static NepanikarConfig parseAndroidConfigFile(File configFile) {
     final config = Config.fromStrings(configFile.readAsLinesSync(encoding: NEPANIKAR_CONF_CODEC));
     return NepanikarConfig.getAndroidData(config);
@@ -29,6 +27,8 @@ class NepanikarConfigParser {
     return NepanikarConfig.getIosData(config);
   }
 }
+
+List<String> get fallbackParseLocales => <String>[Platform.localeName, 'en', 'cs'];
 
 extension NepanikarParserStringExt on String {
   String cleanUnicodes() {
@@ -62,7 +62,7 @@ extension NepanikarParserStringExt on String {
       print(e.toString());
 
       // Trying out fallback languages.
-      for (final locale in NepanikarConfigParser.fallbackParseLocale) {
+      for (final locale in fallbackParseLocales) {
         try {
           dateTime =
               DateFormat(dateTimePattern ?? NepanikarConfigParser.QT_DATE_TIME_PATTERN, locale)


### PR DESCRIPTION
- po migraci se udělá backup file s původním configem staré verze appky
- pokud tento backup file existuje, v Export se objeví tile na export těchto dat - pro případné debugování. Potvrzeno s Verčou že ok
- fix s parsováním datumu - nebralo v potaz Platform locale, takže se parsovaly jen cz a sk - to s tím deníkem se mi zatím nepodařilo reprodukovat ... ale snad toto fixne
- lokalizace pak upravím v jiném PR

<img height="400" src="https://user-images.githubusercontent.com/67197047/213796110-0ed95084-4fb0-4048-bd8f-4d2ec097aaf7.png"/>